### PR TITLE
Skip escaped quotes in cmakeString

### DIFF
--- a/syntax/cmake.vim
+++ b/syntax/cmake.vim
@@ -22,7 +22,7 @@ syn region cmakeRegistry start="\[" end="]" contained oneline contains=cmakeTodo
 
 syn region cmakeGeneratorExpression start="$<" end=">" contained oneline contains=cmakeVariableValue,cmakeProperty,cmakeGeneratorExpressions,cmakeTodo
 
-syn region cmakeString start='"' end='"' contained contains=cmakeTodo,cmakeVariableValue,cmakeEscaped
+syn region cmakeString start='"' end='"' skip='\\"' contained contains=cmakeTodo,cmakeVariableValue,cmakeEscaped
 
 syn region cmakeVariableValue start="${" end="}" contained oneline contains=cmakeVariable,cmakeTodo
 


### PR DESCRIPTION
This is meant to handle the following:

> string(REPLACE "\"" "'" ${FOO} ${BAR})

Initially sent to https://gitlab.kitware.com/cmake/cmake/merge_requests/1196.