### PR TITLE
cmake indent: replace &sw by shiftwidth()

### DIFF
--- a/indent/cmake.vim
+++ b/indent/cmake.vim
@@ -67,19 +67,19 @@ fun! CMakeGetIndent(lnum)
     let ind = ind
   else
     if previous_line =~? cmake_indent_begin_regex
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
     if previous_line =~? cmake_indent_open_regex
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
   endif
 
   " Subtract
   if this_line =~? cmake_indent_end_regex
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   if previous_line =~? cmake_indent_close_regex
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind


### PR DESCRIPTION
Requested here:

https://github.com/vim/vim/commit/37c64c78fd87e086b5a945ad7032787c274e2dcb#commitcomment-24418497