### PR TITLE
Fix spell checking inside CMake functions

### DIFF
--- a/syntax/cmake.vim
+++ b/syntax/cmake.vim
@@ -29,13 +29,13 @@ syn region cmakeRegistry start="\[" end="]" contained oneline contains=cmakeTodo
 
 syn region cmakeGeneratorExpression start="$<" end=">" contained oneline contains=cmakeVariableValue,cmakeProperty,cmakeGeneratorExpressions,cmakeTodo
 
-syn region cmakeString start='"' end='"' contained contains=cmakeTodo,cmakeVariableValue,cmakeEscaped
+syn region cmakeString start='"' end='"' contained contains=cmakeTodo,cmakeVariableValue,cmakeEscaped,@Spell
 
 syn region cmakeVariableValue start="${" end="}" contained oneline contains=cmakeVariable,cmakeTodo,cmakeVariableValue
 
 syn region cmakeEnvironment start="$ENV{" end="}" contained oneline contains=cmakeTodo
 
-syn region cmakeArguments start="(" end=")" contains=ALLBUT,cmakeGeneratorExpressions,cmakeCommand,cmakeCommandConditional,cmakeCommandRepeat,cmakeCommandDeprecated,cmakeCommandManuallyAdded,cmakeArguments,cmakeTodo
+syn region cmakeArguments start="(" end=")" contains=ALLBUT,@Spell,cmakeGeneratorExpressions,cmakeCommand,cmakeCommandConditional,cmakeCommandRepeat,cmakeCommandDeprecated,cmakeCommandManuallyAdded,cmakeArguments,cmakeTodo
 
 syn case match
 


### PR DESCRIPTION
cmakeArguments syntax region used "contains=ALLBUT" which, in
particular, made it contain "@Spell", i.e. told the spell checked to
check everything inside the function arguments. This was undesirable, as
can be seen with the following simple example

	cmake_minimum_required(VERSION 3.1)

	# This should be spel-checked.
	set(this_should_not_be_spel_checked "some value")

in which "spell" misspelling was highlighted in both places and not just
in the first one.

Fix this by explicitly excluding @Spell from cmakeArguments and, to
compensate for the text inside the string used in the arguments not
being spell-checked any more, add it to cmakeString explicitly.