### PR TITLE
Fix syntax highlighting for bracket arguments and comments

### DIFF
--- a/syntax/cmake.vim
+++ b/syntax/cmake.vim
@@ -19,10 +19,10 @@ endif
 let s:keepcpo= &cpo
 set cpo&vim
 
-syn region cmakeBracketArgument start="\[\z(=\?\|=[0-9]*\)\[" end="\]\z1\]" contains=cmakeTodo,@Spell
+syn region cmakeBracketArgument start="\[\z(=*\)\[" end="\]\z1\]" contains=cmakeTodo,@Spell
 
-syn region cmakeComment start="#" end="$" contains=cmakeTodo,@Spell
-syn region cmakeBracketComment start="\[\z(=*\)\[" end="\]\z1\]" contains=cmakeTodo,@Spell
+syn region cmakeComment start="#\(\[=*\[\)\@!" end="$" contains=cmakeTodo,@Spell
+syn region cmakeBracketComment start="#\[\z(=*\)\[" end="\]\z1\]" contains=cmakeTodo,@Spell
 
 syn match cmakeEscaped /\(\\\\\|\\"\|\\n\|\\t\)/ contained
 syn region cmakeRegistry start="\[" end="]" contained oneline contains=cmakeTodo,cmakeEscaped

--- a/test/bracket-args-and-comment.cmake.html.ref
+++ b/test/bracket-args-and-comment.cmake.html.ref
@@ -1,39 +1,39 @@
 <body>
 <pre id='vimCodeElement'>
-<span class="Identifier">message</span>(<span class="ModeMsg">FATAL_ERROR</span> <span class="Comment">[[</span>
-<span class="Comment">This is the first line in a bracket argument with bracket length 1.</span>
-<span class="Comment">No \-escape sequences or ${variable} references are evaluated.</span>
-<span class="Comment">This is always one argument even though it contains a ; character.</span>
-<span class="Comment">It does end in a closing bracket of length 1.</span>
-<span class="Comment">]]</span>)
+<span class="Identifier">message</span>(<span class="ModeMsg">FATAL_ERROR</span> <span class="Constant">[[</span>
+<span class="Constant">This is the first line in a bracket argument with bracket length 1.</span>
+<span class="Constant">No \-escape sequences or ${variable} references are evaluated.</span>
+<span class="Constant">This is always one argument even though it contains a ; character.</span>
+<span class="Constant">It does end in a closing bracket of length 1.</span>
+<span class="Constant">]]</span>)
 
-<span class="Identifier">message</span>(<span class="ModeMsg">FATAL_ERROR</span> <span class="Comment">[=[</span>
-<span class="Comment">This is the first line in a bracket argument with bracket length 1.</span>
-<span class="Comment">No \-escape sequences or ${variable} references are evaluated.</span>
-<span class="Comment">This is always one argument even though it contains a ; character.</span>
-<span class="Comment">The text does not end on a closing bracket of length 0 like ]].</span>
-<span class="Comment">It does end in a closing bracket of length 1.</span>
-<span class="Comment">]=]</span>)
+<span class="Identifier">message</span>(<span class="ModeMsg">FATAL_ERROR</span> <span class="Constant">[=[</span>
+<span class="Constant">This is the first line in a bracket argument with bracket length 1.</span>
+<span class="Constant">No \-escape sequences or ${variable} references are evaluated.</span>
+<span class="Constant">This is always one argument even though it contains a ; character.</span>
+<span class="Constant">The text does not end on a closing bracket of length 0 like ]].</span>
+<span class="Constant">It does end in a closing bracket of length 1.</span>
+<span class="Constant">]=]</span>)
 
-<span class="Identifier">message</span>(<span class="ModeMsg">FATAL_ERROR</span> <span class="Comment">[==[</span>
-<span class="Comment">This is the first line in a bracket argument with bracket length 1.</span>
-<span class="Comment">No \-escape sequences or ${variable} references are evaluated.</span>
-<span class="Comment">This is always one argument even though it contains a ; character.</span>
-<span class="Comment">The text does not end on a closing bracket of length 0 like ]].</span>
-<span class="Comment">It does end in a closing bracket of length 1.</span>
-<span class="Comment">]==]</span>)
+<span class="Identifier">message</span>(<span class="ModeMsg">FATAL_ERROR</span> <span class="Constant">[==[</span>
+<span class="Constant">This is the first line in a bracket argument with bracket length 1.</span>
+<span class="Constant">No \-escape sequences or ${variable} references are evaluated.</span>
+<span class="Constant">This is always one argument even though it contains a ; character.</span>
+<span class="Constant">The text does not end on a closing bracket of length 0 like ]].</span>
+<span class="Constant">It does end in a closing bracket of length 1.</span>
+<span class="Constant">]==]</span>)
 
-<span class="Comment">[[ # this will make a cmake-error but defines a bracket-arguemnt</span>
-<span class="Comment">cmake_minimum_required(VERSION 4.0 FATAL_ERROR) # Should be string-colored</span>
-<span class="Comment">]]</span>
-
-<span class="Comment">#[[</span>
-<span class="Identifier">cmake_minimum_required</span>(<span class="ModeMsg">VERSION</span> 4.0 <span class="ModeMsg">FATAL_ERROR</span>) <span class="Comment"># Should be greyed out</span>
-]] <span class="Identifier">target_link_libraries</span>(t lib)
+<span class="Constant">[[ # this will make a cmake-error but defines a bracket-arguemnt</span>
+<span class="Constant">cmake_minimum_required(VERSION 4.0 FATAL_ERROR) # Should be string-colored</span>
+<span class="Constant">]]</span>
 
 <span class="Comment">#[[</span>
-<span class="Identifier">cmake_minimum_required</span>(<span class="ModeMsg">VERSION</span> 4.0 <span class="ModeMsg">FATAL_ERROR</span>) <span class="Comment"># Should be greyed out</span>
-<span class="Comment">#]] target_link_libraries(t lib)</span>
+<span class="Comment">cmake_minimum_required(VERSION 4.0 FATAL_ERROR) # Should be greyed out</span>
+<span class="Comment">]]</span> <span class="Identifier">target_link_libraries</span>(t lib)
+
+<span class="Comment">#[[</span>
+<span class="Comment">cmake_minimum_required(VERSION 4.0 FATAL_ERROR) # Should be greyed out</span>
+<span class="Comment">#]]</span> <span class="Identifier">target_link_libraries</span>(t lib)
 
 <span class="Comment"># commented bracket-comment</span>
 <span class="Comment">##[[</span>
@@ -41,13 +41,13 @@
 <span class="Comment">#]]</span>
 
 <span class="Comment">#[[This is a bracket comment.</span>
-It runs until the close bracket.]]
+<span class="Comment">It runs until the close bracket.]]</span>
 
-<span class="Identifier">message</span>(<span class="Constant">&quot;First Argument</span><span class="Special">\n</span><span class="Constant">&quot;</span> <span class="Comment">#[[Bracket Comment]] &quot;Second Argument&quot;)</span>
+<span class="Identifier">message</span>(<span class="Constant">&quot;First Argument</span><span class="Special">\n</span><span class="Constant">&quot;</span> <span class="Comment">#[[Bracket Comment]]</span> <span class="Constant">&quot;Second Argument&quot;</span>)
 
 <span class="Comment">#[=[</span>
-comment
-]=]
+<span class="Comment">comment</span>
+<span class="Comment">]=]</span>
 
 </pre>
 </body>

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -6,8 +6,15 @@ TMP=$(mktemp)
 vim -u .vimrc -n -es -c TOhtml -c "w! $TMP" -c 'qa!' $1.cmake >/dev/null 2>&1
 
 # extract the body of the html-file
-sed -i -n -e '/<body>/,$p' $TMP
-sed -i '/<\/body>/q' $TMP
+if [[ "$OSTYPE" =~ ^darwin ]]; then
+	# macOS's builtin sed expects a suffix to create backup before in-place
+	# editing. An empty suffix prevents the backup.
+	sed -i "" -n -e '/<body>/,$p' $TMP
+	sed -i "" '/<\/body>/q' $TMP
+else
+	sed -i -n -e '/<body>/,$p' $TMP
+	sed -i '/<\/body>/q' $TMP
+fi
 
 # diff with references
 diff -u $1.cmake.html.ref $TMP


### PR DESCRIPTION
`Auxiliary/vim/syntax/cmake.vim` incorrectly defines cmakeBracketArguement, cmakeComment and cmakeBracketArgument as
```vim
syn region cmakeBracketArgument start="\[\z(=\?\|=[0-9]*\)\[" end="\]\z1\]" contains=cmakeTodo,@Spell
syn region cmakeComment start="#" end="$" contains=cmakeTodo,@Spell
syn region cmakeBracketComment start="\[\z(=*\)\[" end="\]\z1\]" contains=cmakeTodo,@Spell
```

`cmakeBracketArgument` doesn't match valid bracket argument containing more than one `=` in opening bracket, e.g., `[==[...]==]`, and mismatches invalid text such as `[=0123[...]=0123]`. 

`cmakeBracketComment` should start with `#`.

`cmakeComment` mismatches and overrides bracket comment.

The correct syntaxs should look like
```vim
syn region cmakeBracketArgument start="\[\z(=*\)\[" end="\]\z1\]" contains=cmakeTodo,@Spell
syn region cmakeComment start="#\(\[=*\[\)\@!" end="$" contains=cmakeTodo,@Spell
syn region cmakeBracketComment start="#\[\z(=*\)\[" end="\]\z1\]" contains=cmakeTodo,@Spell
```

The change in `syntax/cmake.vim` is going to be merged into CMake: [merge request](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9061) and [issue](https://gitlab.kitware.com/cmake/cmake/-/issues/25488).