### PR TITLE
Fix typo in dependency provider method keyword

### DIFF
--- a/syntax/cmake.vim
+++ b/syntax/cmake.vim
@@ -2739,7 +2739,6 @@ syn keyword cmakeKWcmake_language contained
             \ DIRECTORY
             \ EVAL
             \ FALSE
-            \ FETCHCONTENT_MAKEAVAILABE_SERIAL
             \ FETCHCONTENT_MAKEAVAILABLE_SERIAL
             \ FETCHCONTENT_SOURCE_DIR_
             \ FETCHCONTENT_TRY_FIND_PACKAGE_MODE


### PR DESCRIPTION
This applies the [fix made in the CMake repository](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9079) to correct a bad keyword with a typo, which made its way into the vim syntax file. Not sure if you want to accept this direct change here or if you prefer to re-run the script to update once the change in CMake is merged and appears in a release, but that won't be for a few months.